### PR TITLE
Change: Use universal release action, not python specific

### DIFF
--- a/.github/workflows/release-pontos-manually.yml
+++ b/.github/workflows/release-pontos-manually.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Release with release action
-        uses: greenbone/actions/release-python@v2
+        uses: greenbone/actions/release@v2
         with:
           version: "3.10"
           conventional-commits: true

--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           version: "3.10"
           conventional-commits: true
+          ref: ${{ github.ref_name }}
           github-user: ${{ secrets.GREENBONE_BOT }}
           github-user-mail: ${{ secrets.GREENBONE_BOT_MAIL }}
           github-user-token: ${{ secrets.GREENBONE_BOT_TOKEN }}


### PR DESCRIPTION
**What** & **Why**:

<!-- Why are these changes necessary? -->
Instead of using greenbone/release-python@v2 we should switch to use greenbone/release@v2 everywhere, so we only need to maintain one release action.
Remove PR_TEMPLATE

**How**:

Magic. DEVOPS-539
**Checklist**:

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


