### PR TITLE
Change: Create conventional commits for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,12 @@ updates:
     allow:
       - dependency-type: direct
       - dependency-type: indirect
+    commit-message:
+      prefix: "Deps"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-
+    commit-message:
+      prefix: "Deps"

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -3,6 +3,10 @@ name: Conventional Commits
 on:
   pull_request:
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   conventional-commits:
     name: Conventional Commits


### PR DESCRIPTION

## What

Create conventional commits for dependabot

## Why

Change dependabot config to create convention commit messages. This allows to include dependency updates in the release changelogs.
