### PR TITLE
Allow to get commit message from git log

### DIFF
--- a/mattermost_notify/git.py
+++ b/mattermost_notify/git.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 from typing import Any, Optional
 
+from pontos.git import Git
 from pontos.terminal import RichTerminal
 
 from mattermost_notify.errors import MattermostNotifyError
@@ -103,11 +104,16 @@ def fill_template(
 
     if commit:
         commit_url = f"{repository_url}/commit/{commit}"
+
+        if not commit_message:
+            commit_message = Git().show(
+                format="format:%s", patch=False, objects=commit  # type: ignore[assignment] # noqa: E501
+            )
     else:
         commit_url = f'{repository_url}/commit/{head_commit.get("id", "")}'
 
-    if not commit_message:
-        commit_message = head_commit.get("message", "").split("\n", 1)[0]
+        if not commit_message:
+            commit_message = head_commit.get("message", "").split("\n", 1)[0]
 
     highlight_str = ""
     if highlight and workflow_status is not Status.SUCCESS:

--- a/poetry.lock
+++ b/poetry.lock
@@ -23,13 +23,13 @@ trio = ["trio (<0.22)"]
 
 [[package]]
 name = "autohooks"
-version = "23.4.0"
+version = "23.7.0"
 description = "Library for managing git hooks"
 optional = false
-python-versions = ">=3.7.2,<4.0.0"
+python-versions = ">=3.8,<4.0"
 files = [
-    {file = "autohooks-23.4.0-py3-none-any.whl", hash = "sha256:2c3b8506890565ad8c9b690db9b70a9b65068ff9f1c2a2d601d2914ad576cfff"},
-    {file = "autohooks-23.4.0.tar.gz", hash = "sha256:6880ad263f0aaab607bbfc1d42afc407de6234320fcff10d75d4e89f4e711ccd"},
+    {file = "autohooks-23.7.0-py3-none-any.whl", hash = "sha256:1fa417891efc3681bdf109cb2e99688948d1f3587d91dab17f1ed9b4428590a4"},
+    {file = "autohooks-23.7.0.tar.gz", hash = "sha256:cf486581fc111122fc3ea394b60a26bc4da0844cf916b6e4fadf90ff97633fe5"},
 ]
 
 [package.dependencies]
@@ -156,13 +156,13 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.5"
+version = "8.1.6"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "click-8.1.5-py3-none-any.whl", hash = "sha256:e576aa487d679441d7d30abb87e1b43d24fc53bffb8758443b1a9e1cee504548"},
-    {file = "click-8.1.5.tar.gz", hash = "sha256:4be4b1af8d665c6d942909916d31a213a106800c47d0eeba73d34da3cbc11367"},
+    {file = "click-8.1.6-py3-none-any.whl", hash = "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"},
+    {file = "click-8.1.6.tar.gz", hash = "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd"},
 ]
 
 [package.dependencies]
@@ -627,13 +627,13 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-
 
 [[package]]
 name = "pontos"
-version = "23.7.6"
+version = "23.7.7"
 description = "Common utilities and tools maintained by Greenbone Networks"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "pontos-23.7.6-py3-none-any.whl", hash = "sha256:c85c802acd7640a2333a523e4ecd9317bb5915620498bdc792a1b073287a5d63"},
-    {file = "pontos-23.7.6.tar.gz", hash = "sha256:c6b9ce4812b5db48686bf418a0bd1edd64da8059a311f6aaa47cf9da1354e56f"},
+    {file = "pontos-23.7.7-py3-none-any.whl", hash = "sha256:00eec64a17873d9730be165688d7fe4e5e63a92f8ed2052e26cd171b4d8a45f2"},
+    {file = "pontos-23.7.7.tar.gz", hash = "sha256:b5be54727b1f8d759278f65fd33c9fe17266d4d42664d7e22803d8f8eb4fcfb6"},
 ]
 
 [package.dependencies]
@@ -787,4 +787,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "5d6f53fe3c49ae7d0835717f9325c4d824c806954ce5fc50874c609ee21e760f"
+content-hash = "005d964206b2a56e7b9a2722bba14e98b60a9b036e420aee2372c13498aa4822"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = ">=3.9"
-pontos = ">=22.7.0"
+pontos = ">=22.7.7"
 httpx = ">=0.23.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION


## What

Allow to get commit message from git log

## Why

If commit is set but not commit message, the git commit message is gathered from git log now. We don't get info about the commit message in GitHub Actions.


