### PR TITLE
Change: Re-enable type checks with mypy in CI

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -33,6 +33,18 @@ jobs:
     with:
       python-version: ${{ matrix.python-version }}
 
+  mypy:
+    name: Check types
+    strategy:
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+    uses: greenbone/workflows/.github/workflows/typing-python.yml@main
+    with:
+      python-version: ${{ matrix.python-version }}
+
   codecov:
     name: Upload coverage to codecov.io
     runs-on: "ubuntu-latest"


### PR DESCRIPTION


## What

Re-enable type checks with mypy in CI

## Why

The mypy check is only included in the generic ci-python.yml workflow which isn't used because of issues with GitHub actions detecting theses runs for satisfying the branch protection rules.

## References

Reverts parts of https://github.com/greenbone/mattermost-notify/pull/180