### PR TITLE
Add warning status to mattermost-notify action

### DIFF
--- a/mattermost_notify/git.py
+++ b/mattermost_notify/git.py
@@ -116,7 +116,7 @@ def fill_template(
             commit_message = head_commit.get("message", "").split("\n", 1)[0]
 
     highlight_str = ""
-    if highlight and workflow_status is not Status.SUCCESS:
+    if highlight and workflow_status not in (Status.SUCCESS, Status.WARNING):
         highlight_str = "".join([f"@{h}\n" for h in highlight])
 
     return template.format(

--- a/mattermost_notify/parser.py
+++ b/mattermost_notify/parser.py
@@ -33,7 +33,7 @@ def parse_args(args=None) -> Namespace:
         "-S",
         "--status",
         type=str,
-        choices=["success", "failure"],
+        choices=["success", "failure", "warning"],
         default=Status.SUCCESS.name,
         help="Status of Job",
     )

--- a/mattermost_notify/status.py
+++ b/mattermost_notify/status.py
@@ -10,6 +10,7 @@ class Status(Enum):
     FAILURE = ":x: failure"
     UNKNOWN = ":grey_question: unknown"
     CANCELLED = ":no_entry_sign: canceled"
+    WARNING = ":warning: warning"
 
     def __str__(self):
         return self.name

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -37,6 +37,21 @@ class FillTemplateTestCase(unittest.TestCase):
 """
         self.assertEqual(expected, actual)
 
+    def test_warning_no_highlight(self):
+        actual = fill_template(
+            highlight=["user1", "user2"],
+            status=Status.WARNING.name,
+        )
+        expected = """#### Status: :warning: warning
+
+| Workflow |  |
+| --- | --- |
+| Repository (branch) |  ([](/tree/)) |
+| Related commit | [](/commit/) |
+
+"""
+        self.assertEqual(expected, actual)
+
     def test_failure_highlight(self):
         actual = fill_template(
             highlight=["user1", "user2"],

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -39,6 +39,17 @@ class ParseArgsTestCase(unittest.TestCase):
         )
         self.assertEqual(parsed_args.status, "failure")
 
+    def test_parse_warning_status(self):
+        parsed_args = parse_args(
+            [
+                "www.url.de",
+                "channel",
+                "-S",
+                "warning",
+            ]
+        )
+        self.assertEqual(parsed_args.status, "warning")
+
     def test_parse_short(self):
         parsed_args = parse_args(
             [


### PR DESCRIPTION
## What

Add warning status to the mattermost notification

## Why

It is needed for cloud reusable workflow 

## References

https://jira.greenbone.net/browse/GCS-1107

## Checklist


- [ ] Tests


