### PR TITLE
Feature: Render short lines for deployment status chatbot

### DIFF
--- a/mattermost_notify/git.py
+++ b/mattermost_notify/git.py
@@ -15,10 +15,10 @@ from pontos.terminal import RichTerminal
 from mattermost_notify.errors import MattermostNotifyError
 from mattermost_notify.parser import parse_args
 from mattermost_notify.post import post
-from mattermost_notify.status import Status
+from mattermost_notify.status import Status, status_to_emoji
 
 LONG_TEMPLATE = (
-    "#### Status: {status}\n\n"
+    "#### Status: {status_emoji} {status_text}\n\n"
     "| Workflow | {workflow} |\n"
     "| --- | --- |\n"
     "| Repository (branch) | {repository} ({branch}) |\n"
@@ -26,7 +26,8 @@ LONG_TEMPLATE = (
     "{highlight}"
 )
 
-SHORT_TEMPLATE = "{status}: {workflow} ({commit}) in {repository} ({branch})"
+SHORT_TEMPLATE = ("{status_emoji} {status_text}: {workflow} | {repository} "
+                  "(b {branch}) {highlight}")
 
 DEFAULT_GIT = "https://github.com"
 
@@ -121,6 +122,8 @@ def fill_template(
 
     return template.format(
         status=workflow_status.value,
+        status_emoji=status_to_emoji(workflow_status),
+        status_text=str(workflow_status).lower(),
         workflow=linker(used_workflow_name, workflow_url),
         repository=linker(repository, repository_url),
         branch=linker(used_branch, branch_url),

--- a/mattermost_notify/git.py
+++ b/mattermost_notify/git.py
@@ -26,8 +26,10 @@ LONG_TEMPLATE = (
     "{highlight}"
 )
 
-SHORT_TEMPLATE = ("{status_emoji} {status_text}: {workflow} | {repository} "
-                  "(b {branch}) {highlight}")
+SHORT_TEMPLATE = (
+    "{status_emoji} {status_text}: {workflow} | {repository} "
+    "(b {branch}) {highlight}"
+)
 
 DEFAULT_GIT = "https://github.com"
 

--- a/mattermost_notify/post.py
+++ b/mattermost_notify/post.py
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from enum import Enum
 import httpx
 from pontos.typing import SupportsStr
 
 from mattermost_notify.errors import MattermostNotifyError
 
-class Colors(Enum):
+
+class Colors:
     """
     Colors namespace for mattermost notifications.
     The colors are borrowed from bootstrap 5.
@@ -19,11 +19,9 @@ class Colors(Enum):
     WARNING = "#e0a800"
     DANGER = "#c82333"
 
+
 def post(
-    url: str,
-    channel: str,
-    text: SupportsStr,
-    color: str = Colors.SECONDARY
+    url: str, channel: str, text: SupportsStr, color: str = Colors.SECONDARY
 ) -> None:
     """
     Post a message to a Mattermost channel.
@@ -38,14 +36,20 @@ def post(
     Raises:
         MattermostNotifyError: If the HTTP request fails.
     """
-    
-    response = httpx.post(url=url, json={"channel": channel, "attachments": [
-            {
-                "color": color,
-                "text": text,
-                "fallback": text,
-            }
-        ]})
+
+    response = httpx.post(
+        url=url,
+        json={
+            "channel": channel,
+            "attachments": [
+                {
+                    "color": color,
+                    "text": text,
+                    "fallback": text,
+                }
+            ],
+        },
+    )
 
     if not response.is_success:
         raise MattermostNotifyError(

--- a/mattermost_notify/post.py
+++ b/mattermost_notify/post.py
@@ -2,14 +2,51 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from enum import Enum
 import httpx
 from pontos.typing import SupportsStr
 
 from mattermost_notify.errors import MattermostNotifyError
 
+class Colors(Enum):
+    """
+    Colors namespace for mattermost notifications.
+    The colors are borrowed from bootstrap 5.
+    """
 
-def post(url: str, channel: str, text: SupportsStr) -> None:
-    response = httpx.post(url=url, json={"channel": channel, "text": text})
+    SECONDARY = "#6c757d"
+    SUCCESS = "#28a745"
+    WARNING = "#e0a800"
+    DANGER = "#c82333"
+
+def post(
+    url: str,
+    channel: str,
+    text: SupportsStr,
+    color: str = Colors.SECONDARY
+) -> None:
+    """
+    Post a message to a Mattermost channel.
+
+    Args:
+        url (str): The Mattermost webhook URL.
+        channel (str): The channel name to post the message to.
+        text (SupportsStr): The message content, markdown formatted.
+        color (str, optional): The color of the message, visible as a
+                               border on the left. Defaults to Colors.SECONDARY.
+
+    Raises:
+        MattermostNotifyError: If the HTTP request fails.
+    """
+    
+    response = httpx.post(url=url, json={"channel": channel, "attachments": [
+            {
+                "color": color,
+                "text": text,
+                "fallback": text,
+            }
+        ]})
+
     if not response.is_success:
         raise MattermostNotifyError(
             "Failed to post on Mattermost. HTTP status was "

--- a/mattermost_notify/status.py
+++ b/mattermost_notify/status.py
@@ -14,3 +14,16 @@ class Status(Enum):
 
     def __str__(self):
         return self.name
+
+
+def status_to_emoji(status: Status) -> str:
+    if status == Status.SUCCESS:
+        return ":white_check_mark:"
+    elif status == Status.FAILURE:
+        return ":x:"
+    elif status == Status.CANCELLED:
+        return ":no_entry_sign:"
+    elif status == Status.WARNING:
+        return ":warning:"
+    else:
+        return ":grey_question:"

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -81,9 +81,8 @@ class FillTemplateTestCase(unittest.TestCase):
             branch="main",
         )
         expected = (
-            ":white_check_mark: success: [SomeWorkflow](https://github.com/foo/bar/actions/runs/w1) "
-            "([Add foo](https://github.com/foo/bar/commit/12345)) in "
-            "[foo/bar](https://github.com/foo/bar) ([main](https://github.com/foo/bar/tree/main))"
+            ":white_check_mark: success: [SomeWorkflow](https://github.com/foo/bar/actions/runs/w1) |"
+            " [foo/bar](https://github.com/foo/bar) (b [main](https://github.com/foo/bar/tree/main)) "
         )
         self.assertEqual(expected, actual)
 

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -6,7 +6,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from mattermost_notify.errors import MattermostNotifyError
-from mattermost_notify.post import post
+from mattermost_notify.post import Colors, post
 
 
 class PostTestCase(unittest.TestCase):
@@ -15,11 +15,13 @@ class PostTestCase(unittest.TestCase):
         response = post_mock.return_value
         response.is_success = True
 
-        post("https://some.mattermost.url", "FooChannel", "Some Message")
+        post("https://some.mattermost.url", "FooChannel", "Some Message", color=Colors.SUCCESS)
 
         post_mock.assert_called_once_with(
             url="https://some.mattermost.url",
-            json={"channel": "FooChannel", "text": "Some Message"},
+            json={'channel': 'FooChannel', 'attachments': [
+                    {'color': '#28a745', 'text': 'Some Message', 'fallback': 'Some Message'}
+                ]},
         )
 
     @patch("mattermost_notify.post.httpx.post", autospec=True)
@@ -36,5 +38,7 @@ class PostTestCase(unittest.TestCase):
 
         post_mock.assert_called_once_with(
             url="https://some.mattermost.url",
-            json={"channel": "FooChannel", "text": "Some Message"},
+            json={'channel': 'FooChannel', 'attachments': [
+                    {'color': '#6c757d', 'text': 'Some Message', 'fallback': 'Some Message'}
+                ]},
         )

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -15,13 +15,25 @@ class PostTestCase(unittest.TestCase):
         response = post_mock.return_value
         response.is_success = True
 
-        post("https://some.mattermost.url", "FooChannel", "Some Message", color=Colors.SUCCESS)
+        post(
+            "https://some.mattermost.url",
+            "FooChannel",
+            "Some Message",
+            color=Colors.SUCCESS,
+        )
 
         post_mock.assert_called_once_with(
             url="https://some.mattermost.url",
-            json={'channel': 'FooChannel', 'attachments': [
-                    {'color': '#28a745', 'text': 'Some Message', 'fallback': 'Some Message'}
-                ]},
+            json={
+                "channel": "FooChannel",
+                "attachments": [
+                    {
+                        "color": "#28a745",
+                        "text": "Some Message",
+                        "fallback": "Some Message",
+                    }
+                ],
+            },
         )
 
     @patch("mattermost_notify.post.httpx.post", autospec=True)
@@ -38,7 +50,14 @@ class PostTestCase(unittest.TestCase):
 
         post_mock.assert_called_once_with(
             url="https://some.mattermost.url",
-            json={'channel': 'FooChannel', 'attachments': [
-                    {'color': '#6c757d', 'text': 'Some Message', 'fallback': 'Some Message'}
-                ]},
+            json={
+                "channel": "FooChannel",
+                "attachments": [
+                    {
+                        "color": "#6c757d",
+                        "text": "Some Message",
+                        "fallback": "Some Message",
+                    }
+                ],
+            },
         )


### PR DESCRIPTION
## What

This PR improves the capability of the Chatbot to render status updates in short lines.
The Status Emoji was seperated from the status text in the templates, so that templating of messages can be more granular.

## Why

Before this change the status updates took up quite a bit of space.
![image](https://github.com/user-attachments/assets/fb410b9c-09ca-44ab-9c8b-6221b9f60e8b)

After this change, the bot will output the status in a single line, allowing to see more status messages at a glance.
If this works as expected, I'd like to move the status Emoji inside the user picture of the bot, which currently displays the avatar of the person that created it.

## References

Ticket: [DEVOPS-1269](https://jira.greenbone.net/browse/DEVOPS-1269)

**This depends on https://github.com/greenbone/actions/pull/1291 to be merged first**

## Checklist
- [x] Tests updated


